### PR TITLE
add logic for decoding already written serato crates.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = tests/*

--- a/examples/create_crates.py
+++ b/examples/create_crates.py
@@ -13,30 +13,29 @@ def list_crates(serato_folder: Path = DEFAULT_SERATO_FOLDER) -> list[Crate]:
 
 
 if __name__ == '__main__':
-    crates = list_crates()
-    print(crates)
-
     #    -root
     #        -lvl1_1
     #             - lvl2_1
     #             - lvl2_2
 
     builder = Builder()
-    lvl2_1 = Crate('lvl2_1')
-    print(f"crate: {lvl2_1}")
-    lvl2_1.add_song("/Users/lukepurnell/nav_music/Russian Circles/Gnosis/01 Tupilak.wav")
-    lvl1_1 = Crate('lvl1_1', children=[lvl2_1])
-    lvl1_1.add_song("/Users/lukepurnell/nav_music/Laker/Noise From The Ruliad/00 Entropy Increasing.mp3")
-    root_crate = Crate('root', children=[lvl1_1])
-    builder.save(root_crate)
+    crate = builder.build_crates_from_filepath(Path('/Users/lukepurnell/Music/_Serato_/Subcrates/root%%lvl1_1%%lvl2_1.crate'))
+    print(crate)
+    #lvl2_1 = Crate('lvl2_1')
+    #print(f"crate: {lvl2_1}")
+    #lvl2_1.add_song(Path("/Users/lukepurnell/nav_music/Russian Circles/Gnosis/01 Tupilak.wav"))
+    #lvl1_1 = Crate('lvl1_1', children=[lvl2_1])
+    #lvl1_1.add_song(Path("/Users/lukepurnell/nav_music/Laker/Noise From The Ruliad/00 Entropy Increasing.mp3"))
+    #root_crate = Crate('root', children=[lvl1_1])
+    #builder.save(root_crate)
 
 
-    lvl2_2 = Crate('lvl2_2')
-    lvl2_2.add_song("/Users/lukepurnell/nav_music/Laker/Noise From The Ruliad/00 Cloud Formation.mp3")
-    lvl1_1 = Crate('lvl1_1', children=[lvl2_2])
-    lvl1_1.add_song("/Users/lukepurnell/nav_music/Laker/Noise From The Ruliad/00 Entropy Increasing.mp3")
-    root_crate = Crate('root', children=[lvl1_1])
-    builder.save(root_crate)
-    root_crate = Crate('root')
-    root_crate.add_song("/Users/lukepurnell/nav_music/Laker/Noise From The Ruliad/00 To Compose To Decompose.mp3")
-    builder.save(root_crate)
+
+    #crate = Crate('test')
+    #crate.add_song(Path('/Users/lukepurnell/Music/Music/Justin Grounds - The Moon Pulled Us Here EP/Justin Grounds - The Moon Pulled Us Here EP - 05 Winds of the World.mp3'))
+    #builder.save(crate)
+
+    subcrates_folder = DEFAULT_SERATO_FOLDER / "SubCrates"
+    for crate_path in subcrates_folder.glob("*crate"):
+        crate = builder.build_crates_from_filepath(crate_path)
+        print(crate)

--- a/src/pyserato/util.py
+++ b/src/pyserato/util.py
@@ -7,10 +7,20 @@ def to_serato_string(string: str) -> str:
     return "\0" + "\0".join(list(string))
 
 
+def from_serato_string(serato_string: str) -> str:
+    assert "\0" == serato_string[0]
+    return serato_string[1::2]
+
+
 def int_to_hexbin(number: int) -> bytes:
     hex_str = format(number, "08x")
     ret = b"".join([bytes([int(hex_str[i: i + 2], 16)]) for i in range(0, len(hex_str), 2)])
     return ret
+
+
+def hexbin_to_int(data: bytes) -> int:
+    hex_str = "".join([format(byte, "02x") for byte in data])
+    return int(hex_str, 16)
 
 
 def sanitize_filename(filename: str) -> str:

--- a/tests/test_crate.py
+++ b/tests/test_crate.py
@@ -1,7 +1,31 @@
 from pathlib import Path
 import pytest
+
+from pyserato import util
 from pyserato.crate import Crate, Builder
 from pyserato.util import DuplicateTrackError
+
+
+def _create_encoded_playlist_section(song_paths: list[Path]) -> bytes:
+    """
+    Unfortunately, forced to use the code under test within the tests itself since we must dynamically set the buffer
+    to the path that is being used by the test. We cannot use a fixed fake data path as the full path is encoded in the
+    crate buffer and this full path will change depending on where the test is being run.
+    :param song_paths:
+    :return:
+    """
+    playlist_section = bytes()
+    for song_path in song_paths:
+        absolute_song_path = Path(song_path).resolve()
+        data = util.to_serato_string(str(absolute_song_path))
+        ptrk_size = util.int_to_hexbin(len(data))
+        otrk_size = util.int_to_hexbin(len(data) + 8)
+        playlist_section += "otrk".encode()
+        playlist_section += otrk_size
+        playlist_section += "ptrk".encode()
+        playlist_section += ptrk_size
+        playlist_section += data.encode()
+    return playlist_section
 
 
 @pytest.fixture
@@ -11,10 +35,10 @@ def child_crate1():
 
 
 @pytest.fixture
-def child_crate2():
+def child_crate2(tmp_path):
     child_crate2 = Crate("child2")
-    fake_path = "/foo/bar/song.mp3"
-    child_crate2.add_song(fake_path, user_root="/User/test")
+    fake_path = Path("fake_data/song.mp3")
+    child_crate2.add_song(fake_path, user_root=tmp_path)
     return child_crate2
 
 
@@ -24,25 +48,23 @@ def root_crate(child_crate1, child_crate2):
     return root_crate
 
 
-def test_create_crate(root_crate, child_crate1, child_crate2):
+def test_create_crate(tmp_path, root_crate, child_crate1, child_crate2):
     assert root_crate.children == [child_crate1, child_crate2]
-    assert child_crate2.song_paths == {Path("/User/test/foo/bar/song.mp3")}
+    assert child_crate2.song_paths == {tmp_path / Path("fake_data/song.mp3")}
 
 
-def test_duplicate_tracks_error(root_crate):
-    song_path = "foo/bar/track.mp3"
-    root_crate.add_song(song_path)
+def test_duplicate_tracks_error(tmp_path, root_crate):
+    song_path = Path("fake_data/song.mp3")
+    root_crate.add_song(tmp_path / song_path)
     with pytest.raises(DuplicateTrackError):
-        root_crate.add_song(song_path)
+        root_crate.add_song(tmp_path / "fake_data/.." / song_path)
 
 
-def test_crate_builder(root_crate, child_crate1, child_crate2, tmp_path):
-    # must make the directory where the crates will be written
-    crate_path = tmp_path / "SubCrates"
-    crate_path.mkdir()
-
+def test_crate_builder(tmp_path, root_crate, child_crate1, child_crate2):
+    subcrates_path = tmp_path / "SubCrates"
+    subcrates_path.mkdir()
     builder = Builder()
-    builder.save(root_crate, tmp_path)
+    builder.save(root_crate, subcrates_path.parent)
     crate_names_to_content = {}
     expected_crate_names_content = {
         "root%%child1.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e"
@@ -52,15 +74,15 @@ def test_crate_builder(root_crate, child_crate1, child_crate2, tmp_path):
         "root%%child2.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e"
         b"\x00r\x00a\x00t\x00o\x00\x00\x00S\x00c\x00r\x00a\x00t"
         b"\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a"
-        b"\x00t\x00eotrk\x00\x00\x00>ptrk\x00\x00\x006\x00/\x00U"
-        b"\x00s\x00e\x00r\x00/\x00t\x00e\x00s\x00t\x00/\x00f"
-        b"\x00o\x00o\x00/\x00b\x00a\x00r\x00/\x00s\x00o\x00n"
-        b"\x00g\x00.\x00m\x00p\x003",
+        b"\x00t\x00e",
         "root.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e\x00r\x00a"
         b"\x00t\x00o\x00\x00\x00S\x00c\x00r\x00a\x00t\x00c\x00h"
         b"\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a\x00t\x00e",
     }
-    for f in crate_path.iterdir():
+    expected_crate_names_content["root%%child2.crate"] += _create_encoded_playlist_section(
+        list(child_crate2.song_paths)
+    )
+    for f in subcrates_path.iterdir():
         crate_name = f.name
         crate_content = f.read_bytes()
         crate_names_to_content[crate_name] = crate_content
@@ -69,107 +91,156 @@ def test_crate_builder(root_crate, child_crate1, child_crate2, tmp_path):
 
 
 def test_crate_no_overwrite(tmp_path):
-    # must make the directory where the crates will be written
-    crate_path = tmp_path / "SubCrates"
-    crate_path.mkdir()
     child_crate1 = Crate("child1")
     root_crate = Crate("root", children=[child_crate1])
-    root_crate.add_song("/foo/bar.mp3", user_root="/User/test")
+    root_crate.add_song(Path("foo/bar.mp3"), user_root=tmp_path)
 
+    subcrates_path = tmp_path / "SubCrates"
+    subcrates_path.mkdir()
     builder = Builder()
-    builder.save(root_crate, tmp_path)
+    builder.save(root_crate, subcrates_path.parent)
     crate_names_to_content = {}
     expected_crate_names_content = {
-        "root.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e\x00r\x00a\x00t\x00o\x00\x00\x00S\x00c\x00r\x00a"
-                      b"\x00t\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a\x00t\x00eotrk\x00\x00\x004ptrk"
-                      b"\x00\x00\x00,\x00/\x00U\x00s\x00e\x00r\x00/\x00t\x00e\x00s\x00t\x00/\x00f\x00o\x00o\x00/\x00b"
-                      b"\x00a\x00r\x00.\x00m\x00p\x003",
+        "root.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e\x00r\x00a"
+        b"\x00t\x00o\x00\x00\x00S\x00c\x00r\x00a\x00t\x00c\x00h"
+        b"\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a\x00t\x00e",
         "root%%child1.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e\x00r\x00a\x00t\x00o\x00\x00\x00S\x00c"
-                              b"\x00r\x00a\x00t\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a\x00t\x00e",
+        b"\x00r\x00a\x00t\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a\x00t\x00e",
     }
+    expected_crate_names_content["root.crate"] += _create_encoded_playlist_section(list(root_crate.song_paths))
 
-    for f in crate_path.iterdir():
-        crate_name = f.name
-        crate_content = f.read_bytes()
-        crate_names_to_content[crate_name] = crate_content
+    for f in subcrates_path.iterdir():
+        if f.is_file():
+            crate_name = f.name
+            crate_content = f.read_bytes()
+            crate_names_to_content[crate_name] = crate_content
 
     assert expected_crate_names_content == crate_names_to_content
 
     child_crate2 = Crate("child2")
     root_crate = Crate("root", children=[child_crate2])
-    child_crate2.add_song("/foo/bar.mp3", user_root="/User/test")
+    child_crate2.add_song(Path("foo/bar.mp3"), user_root=tmp_path)
 
-    builder.save(root_crate, tmp_path)
+    builder.save(root_crate, subcrates_path.parent)
     crate_names_to_content = {}
     expected_crate_names_content = {
-        "root.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e\x00r\x00a\x00t\x00o\x00\x00\x00S\x00c\x00r\x00a"
-                      b"\x00t\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a\x00t\x00eotrk\x00\x00\x004ptrk"
-                      b"\x00\x00\x00,\x00/\x00U\x00s\x00e\x00r\x00/\x00t\x00e\x00s\x00t\x00/\x00f\x00o\x00o\x00/\x00b"
-                      b"\x00a\x00r\x00.\x00m\x00p\x003",
-        "root%%child2.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e\x00r\x00a\x00t\x00o\x00\x00\x00S\x00c"
-                              b"\x00r\x00a\x00t\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a\x00t\x00eotrk"
-                              b"\x00\x00\x004ptrk\x00\x00\x00,\x00/\x00U\x00s\x00e\x00r\x00/\x00t\x00e\x00s\x00t"
-                              b"\x00/\x00f\x00o\x00o\x00/\x00b\x00a\x00r\x00.\x00m\x00p\x003",
-        "root%%child1.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e\x00r\x00a\x00t\x00o\x00\x00\x00S\x00c"
-                              b"\x00r\x00a\x00t\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a\x00t\x00e",
+        "root%%child1.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e"
+        b"\x00r\x00a\x00t\x00o\x00\x00\x00S\x00c\x00r\x00a\x00t"
+        b"\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a"
+        b"\x00t\x00e",
+        "root%%child2.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e"
+        b"\x00r\x00a\x00t\x00o\x00\x00\x00S\x00c\x00r\x00a\x00t"
+        b"\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a"
+        b"\x00t\x00e",
+        "root.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e\x00r\x00a"
+        b"\x00t\x00o\x00\x00\x00S\x00c\x00r\x00a\x00t\x00c\x00h"
+        b"\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a\x00t\x00e",
     }
+    expected_crate_names_content["root%%child2.crate"] += _create_encoded_playlist_section(
+        list(child_crate2.song_paths)
+    )
+    expected_crate_names_content["root.crate"] += _create_encoded_playlist_section(list(child_crate2.song_paths))
 
-    for f in crate_path.iterdir():
-        crate_name = f.name
-        crate_content = f.read_bytes()
-        crate_names_to_content[crate_name] = crate_content
+    for f in subcrates_path.iterdir():
+        if f.is_file():
+            crate_name = f.name
+            crate_content = f.read_bytes()
+            crate_names_to_content[crate_name] = crate_content
 
     assert expected_crate_names_content == crate_names_to_content
 
 
 def test_crate_overwrite(tmp_path):
-    # must make the directory where the crates will be written
-    crate_path = tmp_path / "SubCrates"
-    crate_path.mkdir()
+    subcrates_path = tmp_path / "SubCrates"
+    subcrates_path.mkdir()
     child_crate1 = Crate("child1")
     root_crate = Crate("root", children=[child_crate1])
-    root_crate.add_song("/foo/bar.mp3", user_root="/User/test")
+    root_crate.add_song(Path("foo/bar.mp3"), user_root=tmp_path)
 
     builder = Builder()
-    builder.save(root_crate, tmp_path)
+    builder.save(root_crate, subcrates_path.parent)
     crate_names_to_content = {}
     expected_crate_names_content = {
-        "root.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e\x00r\x00a\x00t\x00o\x00\x00\x00S\x00c\x00r\x00a"
-                      b"\x00t\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a\x00t\x00eotrk\x00\x00\x004ptrk"
-                      b"\x00\x00\x00,\x00/\x00U\x00s\x00e\x00r\x00/\x00t\x00e\x00s\x00t\x00/\x00f\x00o\x00o\x00/\x00b"
-                      b"\x00a\x00r\x00.\x00m\x00p\x003",
+        "root.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e\x00r\x00a"
+        b"\x00t\x00o\x00\x00\x00S\x00c\x00r\x00a\x00t\x00c\x00h"
+        b"\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a\x00t\x00e",
         "root%%child1.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e\x00r\x00a\x00t\x00o\x00\x00\x00S\x00c"
-                              b"\x00r\x00a\x00t\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a\x00t\x00e",
+        b"\x00r\x00a\x00t\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a\x00t\x00e",
     }
+    expected_crate_names_content["root.crate"] += _create_encoded_playlist_section(list(root_crate.song_paths))
 
-    for f in crate_path.iterdir():
-        crate_name = f.name
-        crate_content = f.read_bytes()
-        crate_names_to_content[crate_name] = crate_content
+    for f in subcrates_path.iterdir():
+        if f.is_file():
+            crate_name = f.name
+            crate_content = f.read_bytes()
+            crate_names_to_content[crate_name] = crate_content
 
     assert expected_crate_names_content == crate_names_to_content
 
     child_crate2 = Crate("child2")
     root_crate = Crate("root", children=[child_crate2])
-    child_crate2.add_song("/foo/bar.mp3", user_root="/User/test")
+    child_crate2.add_song(Path("foo/bar.mp3"), user_root=tmp_path)
 
-    builder.save(root_crate, tmp_path, overwrite=True)
+    builder.save(root_crate, subcrates_path.parent, overwrite=True)
     crate_names_to_content = {}
+
     # here the contents of the root crate have been overwritten
     expected_crate_names_content = {
+        "root%%child1.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e"
+        b"\x00r\x00a\x00t\x00o\x00\x00\x00S\x00c\x00r\x00a\x00t"
+        b"\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a"
+        b"\x00t\x00e",
+        "root%%child2.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e"
+        b"\x00r\x00a\x00t\x00o\x00\x00\x00S\x00c\x00r\x00a\x00t"
+        b"\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a"
+        b"\x00t\x00e",
         "root.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e\x00r\x00a\x00t\x00o\x00\x00\x00S\x00c\x00r\x00a"
-                      b"\x00t\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a\x00t\x00e",
-        "root%%child2.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e\x00r\x00a\x00t\x00o\x00\x00\x00S\x00c"
-                              b"\x00r\x00a\x00t\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a\x00t\x00eotrk"
-                              b"\x00\x00\x004ptrk\x00\x00\x00,\x00/\x00U\x00s\x00e\x00r\x00/\x00t\x00e\x00s\x00t"
-                              b"\x00/\x00f\x00o\x00o\x00/\x00b\x00a\x00r\x00.\x00m\x00p\x003",
-        "root%%child1.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e\x00r\x00a\x00t\x00o\x00\x00\x00S\x00c"
-                              b"\x00r\x00a\x00t\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a\x00t\x00e",
+        b"\x00t\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a\x00t\x00e",
     }
+    expected_crate_names_content["root%%child2.crate"] += _create_encoded_playlist_section(
+        list(child_crate2.song_paths)
+    )
 
-    for f in crate_path.iterdir():
-        crate_name = f.name
-        crate_content = f.read_bytes()
-        crate_names_to_content[crate_name] = crate_content
+    for f in subcrates_path.iterdir():
+        if f.is_file():
+            crate_name = f.name
+            crate_content = f.read_bytes()
+            crate_names_to_content[crate_name] = crate_content
 
     assert expected_crate_names_content == crate_names_to_content
+
+
+def test_build_crate_from_filepath(tmp_path):
+    builder = Builder()
+    crates_to_content = {
+        "root%%child1.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e"
+        b"\x00r\x00a\x00t\x00o\x00\x00\x00S\x00c\x00r\x00a\x00t"
+        b"\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a"
+        b"\x00t\x00e",
+        "root%%child2.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e"
+        b"\x00r\x00a\x00t\x00o\x00\x00\x00S\x00c\x00r\x00a\x00t"
+        b"\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a"
+        b"\x00t\x00e",
+        "root.crate": b"vrsn\x00\x00\x008\x001\x00.\x000\x00/\x00S\x00e\x00r\x00a\x00t\x00o\x00\x00\x00S\x00c\x00r\x00a"
+        b"\x00t\x00c\x00h\x00L\x00i\x00v\x00e\x00\x00\x00C\x00r\x00a\x00t\x00e",
+    }
+    song_path = tmp_path / "foo" / "bar.mp3"
+    crates_to_content["root%%child2.crate"] += _create_encoded_playlist_section([song_path])
+
+    child2 = Crate("child2")
+    child2.add_song(song_path)
+    expected_crates = [
+        Crate("root", children=[Crate("child1")]),
+        Crate("root", children=[child2]),
+        Crate("root"),
+    ]
+    for i, (crate_name, contents) in enumerate(crates_to_content.items()):
+        path = tmp_path / Path(crate_name)
+        path.write_bytes(contents)
+        crate = builder.build_crates_from_filepath(path)
+        expected_crate = expected_crates[i]
+        assert crate.name == expected_crate.name
+        assert crate.song_paths == expected_crate.song_paths
+        if crate.children:
+            assert crate.children[0].name == expected_crate.children[0].name
+            assert crate.children[0].song_paths == expected_crate.children[0].song_paths

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,15 @@
-from pyserato.util import int_to_hexbin
+from pyserato.util import int_to_hexbin, hexbin_to_int
 
 
 def test_int_to_hexbin():
     hexbin = int_to_hexbin(133)
     assert hexbin == b"\x00\x00\x00\x85"
+
+
+def test_hexbin_to_int():
+    assert 133 == hexbin_to_int(b"\x00\x00\x00\x85")
+
+
+def test_int_to_hexbin_hexbin_to_int():
+    for i in range(1, 1025):
+        assert i == hexbin_to_int(int_to_hexbin(i))


### PR DESCRIPTION
* Use tmp path for reading and writing to disk in unit tests instead of fake data.
   * Unfortunately, forced to use the code under test within the tests itself since we must dynamically set the buffer to the path that is being used by the test. We cannot use a fixed fake data path as the full path is encoded in the crate buffer and this full path will change depending on where the test is being run.
* do not assert that the song path exists when adding a song to a crate. As long as the path of the track is present on the host system where the Serato crates are located at the point of opening Serato, the tracks will be found.