### PR TITLE
Fix logic for parsing crates from Serato file path

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-omit = tests/*

--- a/.github/workflows/main_test.yaml
+++ b/.github/workflows/main_test.yaml
@@ -26,4 +26,4 @@ jobs:
           flake8 --max-line-length=120 src tests
           mypy src tests
           coverage run -m pytest tests
-          coverage report --fail-under=95
+          coverage report --fail-under=98

--- a/README.md
+++ b/README.md
@@ -1,39 +1,11 @@
 # pyserato
-Programatically create crates in Serato.
+Programmatically create and read/write Serato crates.
 
-Example use using the DEFAULT_SERATO_FOLDER.
+Example use using the DEFAULT_SERATO_FOLDER (~/Music/_Serato_).
 This can be overwritten to a non default location by passing the desired root in to the `builder.save()` API.
 
-```python
-from pathlib import Path
-from pyserato.crate import DEFAULT_SERATO_FOLDER, Crate, Builder
-
-def list_crates_sync(serato_folder: Path = DEFAULT_SERATO_FOLDER) -> list[Crate]:
-    all_crates = []
-    subcrates_folder = serato_folder / "SubCrates"
-    crates = [
-        Crate(name.stem) for name in subcrates_folder.glob("*.crate")
-    ]
-    all_crates.extend(crates)
-    return all_crates
-
-if __name__ == '__main__':
-    crates = list_crates_sync()
-    print(crates)
-    
-    child_crate3 = Crate('child3')
-    child_crate3.add_song("/Users/lukepurnell/nav_music/Laker/Noise From The Ruliad/00 Cloud Formation.mp3")
-    child_crate = Crate('child1', children=[child_crate3])
-    child_crate.add_song("/Users/lukepurnell/nav_music/Russian Circles/Gnosis/01 Tupilak.wav")
-    child_crate2 = Crate('child2')
-    child_crate2.add_song("/Users/lukepurnell/nav_music/Laker/Noise From The Ruliad/00 Entropy Increasing.mp3")
-    child_crate.add_song("/Users/lukepurnell/nav_music/Laker/Noise From The Ruliad/00 Cloud Formation.mp3")
-    root_crate = Crate('root', children=[child_crate, child_crate2])
-    builder = Builder()
-    builder.save(root_crate)
-```
-
-The following shows two different methods for creating the following Crate structure:
+## Writing Crates
+The following shows two different methods for creating and writing the following Crate structure:
 
 ```python
     #    -root
@@ -89,3 +61,48 @@ crate = Crate('foo')
 crate.add_song('foo/bar/track.mp3')
 crate.add_song('foo/bar/track.mp3') # raises DuplicateTrackError
 ```
+
+## Reading Crates
+
+Reading Crates from file in to the `Crate` datastructure provided by this library.
+```python
+builder = Builder()
+subcrates_folder = DEFAULT_SERATO_FOLDER / "SubCrates"
+crates = builder.parse_crates_from_root_path(subcrates_folder)
+```
+
+## Serato Database Format
+
+Serato stores its crate information in a directory called _Serato_/Subcrates in the root of the drive where the music is located (this is true when the music is on a removable drive, unclear what happens when it's on the primary drive of the computer). Each file in this directory corresponds to one crate and will be named CrateName.crate.
+The crate hierachy tree is encoded in the CrateName.
+
+The format of these .crate files is a concatenated sequence of records. Each record starts with a 4-byte ASCII tag, followed by a 4-byte big-endian length (always at least one), followed by the bytes of the record. The way the bytes are interpreted depends on the tag and follows this table:
+
+Tag pattern	Data format
+o*	Nested sequence of records
+t*	UTF-16 big-endian text
+p*	UTF-16 big-endian text, value is a path (relative to the root of the drive)
+u*	Unsigned 32-bit big-endian value
+s*	Signed 32-big big-endian value
+b*	Byte value
+vrsn	UTF-16 big-endian text, value is crate format version
+Here are the meanings of specific fields:
+
+Tag name	Meaning
+otrk	Track
+ptrk	Path to track file (nested inside otrk)
+Here's an example of the structure of the .crate file:
+
+  [
+    ('vrsn', '1.0/Serato ScratchLive Crate'),
+    ('otrk', [
+      ('ptrk', 'Music/Daft Punk - 2001 - Discovery/06 Night Vision.mp3')]),
+    ('otrk', [
+      ('ptrk', 'Music/Daft Punk - 2013 - Random Access Memories/05 Instant Crush.mp3')]),
+  ]
+Note that the name of the crate is *not* encoded in the crate itself; it's only present in the filename. Also, some not-very-useful fields are omitted in this example; for example there appear to be fields that give the order that the title/artist/key/BPM columns should appear in the browser.
+
+The encoding of the path of the file seems to change. Sometimes it is utf-8, other times it is latin-1. It is still not clear to me why this switch is made. The presence of a 'orvc' tag after a track path seems to indicate that latin-1 encoding is used. Else the default is utf-8.
+
+## TODO
+1. Parse additional Serato info.

--- a/examples/create_crates.py
+++ b/examples/create_crates.py
@@ -19,8 +19,12 @@ if __name__ == '__main__':
     #             - lvl2_2
 
     builder = Builder()
-    crate = builder.build_crates_from_filepath(Path('/Users/lukepurnell/Music/_Serato_/Subcrates/root%%lvl1_1%%lvl2_1.crate'))
-    print(crate)
+    path = '/Users/lukepurnell/subbox/docker-compose/filebrowser/data/users/emc/Subcrates/all%%new serato crate%%nested%%new music.crate'
+    #path = '/Users/lukepurnell/Music/_Serato_/Subcrates/all%%new serato crate%%nested%%new music.crate'
+    #path = '/Users/lukepurnell/Music/_Serato_/Subcrates/all%%test.crate'
+    #path = '/Users/lukepurnell/Music/_Serato_/Subcrates/all%%NOPLAYLIST.crate'
+    #crate = builder.build_crates_from_filepath(Path(path))
+    #print(crate)
     #lvl2_1 = Crate('lvl2_1')
     #print(f"crate: {lvl2_1}")
     #lvl2_1.add_song(Path("/Users/lukepurnell/nav_music/Russian Circles/Gnosis/01 Tupilak.wav"))
@@ -31,11 +35,19 @@ if __name__ == '__main__':
 
 
 
-    #crate = Crate('test')
-    #crate.add_song(Path('/Users/lukepurnell/Music/Music/Justin Grounds - The Moon Pulled Us Here EP/Justin Grounds - The Moon Pulled Us Here EP - 05 Winds of the World.mp3'))
-    #builder.save(crate)
+    #child1_crate = Crate('test-child1')
+    #child1_crate.add_song(Path("/Users/lukepurnell/Music/Russian Circles - Gnosis/Russian Circles - Gnosis - 03 Gnosis.mp3"))
+    #child2_crate = Crate('test-child2', children=[child1_crate])
+    #child2_crate.add_song(Path("/Users/lukepurnell/Music/Laker - Noise From The Ruliad/Laker - Noise From The Ruliad - 02 Points Break At Break Points.mp3"))
+    #child3_crate = Crate('test-child3', children=[child1_crate])
+    #child3_crate.add_song(Path("/Users/lukepurnell/Music/Laker - Noise From The Ruliad/Laker - Noise From The Ruliad - 07 To Compose To Decompose.mp3"))
+    #root_crate = Crate('root', children=[child1_crate, child2_crate, child3_crate])
+    #root_crate.add_song(Path("/Users/lukepurnell/Music/Justin Grounds - The Moon Pulled Us Here EP/Justin Grounds - The Moon Pulled Us Here EP - 02 Santa Margharita.mp3"))
+    #crate.add_song(Path("/Users/lukepurnell/Music/serato_export_test/subbox_export/Cloudkicker/Solitude/05 - I’m Glad You Still Have a Sense of Humor….flac"))
+    #crate.add_song(Path("/Users/lukepurnell/Music/beets/Arca/Arca/04 Urchin.mp3"))
+    ##crate.add_song(Path("…"))
+    #builder.save(root_crate)
 
     subcrates_folder = DEFAULT_SERATO_FOLDER / "SubCrates"
-    for crate_path in subcrates_folder.glob("*crate"):
-        crate = builder.build_crates_from_filepath(crate_path)
-        print(crate)
+    crates = builder.parse_crates_from_root_path(subcrates_folder)
+    print(crates)

--- a/src/pyserato/util.py
+++ b/src/pyserato/util.py
@@ -3,19 +3,36 @@ import re
 INVALID_CHARACTERS_REGEX = re.compile(r"[^A-Za-z0-9_ ]", re.IGNORECASE)
 
 
-def to_serato_string(string: str) -> str:
-    return "\0" + "\0".join(list(string))
+def serato_decode(s: bytes) -> str:
+    """
+    Decode a string that's been encoded in to bytes Serato style.
+    This is a Python implementation of Java's bytes to string utf16 which Serato appears to use from looking at:
+    https://github.com/markusschmitz53/serato-itch-sync
+    :param s:
+    :return:
+    """
+    result = ""
+    while s:
+        chunk = s[:2]
+        chunk = chunk[::-1]
+        result += chunk.decode("utf16")
+        s = s[2:]
+    return result
 
 
-def from_serato_string(serato_string: str) -> str:
-    assert "\0" == serato_string[0]
-    return serato_string[1::2]
-
-
-def int_to_hexbin(number: int) -> bytes:
-    hex_str = format(number, "08x")
-    ret = b"".join([bytes([int(hex_str[i: i + 2], 16)]) for i in range(0, len(hex_str), 2)])
-    return ret
+def serato_encode(s: str) -> bytes:
+    """
+    Encode a string Serato style.
+    This is a Python implementation of Java's 'writeChars' which Serato appears to use from looking at:
+    https://github.com/markusschmitz53/serato-itch-sync
+    :param s:
+    :return:
+    """
+    result = []
+    for c in s:
+        result.append(int.from_bytes(c.encode("utf16"), byteorder="big") >> 0 & 255)
+        result.append(int.from_bytes(c.encode("utf16"), byteorder="big") >> 8 & 255)
+    return bytes(result)
 
 
 def hexbin_to_int(data: bytes) -> int:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,15 +1,6 @@
-from pyserato.util import int_to_hexbin, hexbin_to_int
+from pyserato.util import serato_encode, serato_decode
 
 
-def test_int_to_hexbin():
-    hexbin = int_to_hexbin(133)
-    assert hexbin == b"\x00\x00\x00\x85"
-
-
-def test_hexbin_to_int():
-    assert 133 == hexbin_to_int(b"\x00\x00\x00\x85")
-
-
-def test_int_to_hexbin_hexbin_to_int():
-    for i in range(1, 1025):
-        assert i == hexbin_to_int(int_to_hexbin(i))
+def test_serato_encode_decode():
+    test_s = "/Users/lukepurnell/Music/beets/Arca/Arca/10 Desafío.mp3"
+    assert serato_decode(serato_encode(test_s)) == test_s


### PR DESCRIPTION
* Fix logic for parsing crates from Serato file path
* Add new `parse_crates_from_root_path` API for crate builder to return complete crate tree from subcrates path.
* Add necessary dunder methods to Crate for comparison, adding and deep copying.
* Update tests and README